### PR TITLE
chore: support `cargo-binstall`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ rayon = "~1.4.0"
 regex = "1"
 termcolor = "~1.1.0"
 walkdir = "2"
+
+[package.metadata.binstall]


### PR DESCRIPTION
Resolves #13.